### PR TITLE
feat: 🎸 add PATCH /auth/profile route and Enhancements

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,17 +3,28 @@ import { AuthService } from './auth.service';
 import { Request, Response } from 'express';
 import { RegisterUserDto } from './dtos/register-user.dto';
 import { UserDocument } from '../models/user';
+import { UpdateProfileDto } from './dtos/update-profile.dto';
 
 @Service()
 export class AuthController {
   constructor(@Inject() private readonly service: AuthService) {
     this.register = this.register.bind(this);
     this.getProfile = this.getProfile.bind(this);
+    this.updateProfile = this.updateProfile.bind(this);
   }
 
   async register(req: Request, res: Response) {
-    const userData = req.body as RegisterUserDto;
-    const user = await this.service.register(userData);
+    const { username, password, confirmPassword, email, contact, gender, age } =
+      req.body as RegisterUserDto;
+    const user = await this.service.register({
+      username,
+      password,
+      confirmPassword,
+      email,
+      contact,
+      gender,
+      age
+    });
     return res.status(201).json({
       status: 'success',
       data: user
@@ -24,6 +35,23 @@ export class AuthController {
     const user = req.user as UserDocument;
     const profile = await this.service.findOneBy({
       _id: user._id
+    });
+    return res.status(200).json({
+      status: 'success',
+      data: profile
+    });
+  }
+
+  async updateProfile(req: Request, res: Response) {
+    const user = req.user as UserDocument;
+    const { username, email, contact, gender, age } =
+      req.body as UpdateProfileDto;
+    const profile = await this.service.updateProfile(user.id, {
+      username,
+      email,
+      contact,
+      gender,
+      age
     });
     return res.status(200).json({
       status: 'success',

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Service } from 'typedi';
 import { User } from '../models/user';
 import { RegisterUserDto } from './dtos/register-user.dto';
 import { FilterQuery } from 'mongoose';
+import { UpdateProfileDto } from './dtos/update-profile.dto';
 
 @Service()
 export class AuthService {
@@ -32,5 +33,16 @@ export class AuthService {
 
   findOneBy(condition: FilterQuery<typeof User>) {
     return this.model.findOne(condition).exec();
+  }
+
+  async updateProfile(id: string, payload: UpdateProfileDto) {
+    const parsedData = this.parseData(payload);
+    const newProfile = await this.model
+      .findOneAndUpdate({ _id: id }, parsedData, {
+        new: true
+      })
+      .exec();
+    /* because 'findOneAndUpdate()' returns the original document by default. */
+    return newProfile?.toJSON();
   }
 }

--- a/src/auth/dtos/register-user.dto.ts
+++ b/src/auth/dtos/register-user.dto.ts
@@ -2,6 +2,7 @@ export interface RegisterUserDto {
   username: string;
   email: string;
   password: string;
+  confirmPassword: string;
   contact?: string;
   gender: 'Male' | 'Female' | 'Others';
   age: number;

--- a/src/auth/dtos/update-profile.dto.ts
+++ b/src/auth/dtos/update-profile.dto.ts
@@ -1,0 +1,5 @@
+import { RegisterUserDto } from './register-user.dto';
+
+export type UpdateProfileDto = Partial<
+  Omit<RegisterUserDto, 'password' | 'confirmPassword'>
+>;

--- a/src/auth/schemas/auth.schema.ts
+++ b/src/auth/schemas/auth.schema.ts
@@ -74,3 +74,34 @@ export const loginSchema = object({
     password: string({ required_error: 'Password is required' })
   })
 });
+
+export const updateProfileSchema = object({
+  body: object({
+    username: string()
+      .min(8, 'Username must have at least 8 characters')
+      .max(20, 'Username should not exceed 20 characters')
+      .regex(/^[a-z][a-z0-9_]{7,19}$/, 'Invalid username')
+      .refine(isUsernameUnique, { message: 'Username already in use' })
+      .optional(),
+
+    email: string()
+      .email()
+      .refine(isEmailUnique, { message: 'Email already in use' })
+      .optional(),
+
+    contact: string()
+      .regex(/^\d{6,20}$/, 'Invalid contact number')
+      .refine(isContactUnique, { message: 'Contact number already in use' })
+      .optional(),
+
+    gender: string()
+      .refine(isGenderValid, {
+        message: `Gender must be either 'Male', 'Female' or 'Others'`
+      })
+      .optional(),
+
+    age: number({
+      invalid_type_error: 'Age must be a number'
+    }).optional()
+  })
+});

--- a/src/configs/passport.ts
+++ b/src/configs/passport.ts
@@ -38,10 +38,12 @@ const jwtStrategyOptions: JWTStrategyOptions = {
 
 passport.use(
   new JWTStrategy(jwtStrategyOptions, (jwtPayload, done) => {
-    User.findOne({ username: jwtPayload.username })
+    User.findOne({ _id: jwtPayload._id })
       .then((user: UserDocument | null) => {
         if (!user) {
-          return done(null, false, 'Invalid token');
+          return done(null, false, {
+            message: 'Invalid token'
+          });
         }
         return done(null, user, jwtPayload);
       })

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -3,7 +3,11 @@ import passport from 'passport';
 import Container from 'typedi';
 import { AuthController } from '../auth/auth.controller';
 import { validate } from '../middlewares/validate';
-import { loginSchema, registerUserSchema } from '../auth/schemas/auth.schema';
+import {
+  loginSchema,
+  registerUserSchema,
+  updateProfileSchema
+} from '../auth/schemas/auth.schema';
 import { UserDocument } from '../models/user';
 import CustomError from '../errors/custom-error';
 import wrapNext from '../middlewares/wrap-next';
@@ -40,5 +44,10 @@ router.post(
 
 router.use(authenticateJWT);
 router.get('/profile', wrapNext(authController.getProfile));
+router.patch(
+  '/profile',
+  validate(updateProfileSchema),
+  wrapNext(authController.updateProfile)
+);
 
 export default router;


### PR DESCRIPTION
## Overview
This pull request introduces a new profile update API and includes enhancements to existing functionality. Below is a summary of the key updates:

### Changes
-  Added a new API endpoint for updating user profiles.

- Modified the Passport JWT strategy to compare `_id` instead of `username` for authentication.

- Updated the registration route to parse the request body object for improved data handling.

- Updated the profile update route to parse the request body object for improved data handling.

### Notes
- Ensure to thoroughly test the new profile update API and the changes in authentication strategy.
- The Passport JWT strategy now compares `_id` for authentication, enhancing security.