### PR TITLE
feat: 🎸 Add Routes for Daily, Weekly, and Monthly Balance Trends

### DIFF
--- a/src/routes/wallet.routes.ts
+++ b/src/routes/wallet.routes.ts
@@ -4,7 +4,8 @@ import { WalletController } from '../wallets/wallet.controller';
 import {
   addWalletSchema,
   updateWalletSchema,
-  walletIdParamSchema
+  walletIdParamSchema,
+  walletTrendQuerySchema
 } from '../wallets/schemas/wallet.schema';
 import wrapNext from '../middlewares/wrap-next';
 import { validate } from '../middlewares/validate';
@@ -33,5 +34,10 @@ router.delete(
   validate(walletIdParamSchema),
   wrapNext(walletController.delete)
 );
-
+router.get(
+  '/trends/:id',
+  validate(walletIdParamSchema),
+  validate(walletTrendQuerySchema),
+  wrapNext(walletController.getWalletBalanceTrend)
+);
 export default router;

--- a/src/wallets/dtos/get-wallet-trend.dto.ts
+++ b/src/wallets/dtos/get-wallet-trend.dto.ts
@@ -1,0 +1,5 @@
+import { WalletTrendType } from '../types/wallet.trend.types';
+
+export interface GetWalletTrendDto {
+  type?: WalletTrendType;
+}

--- a/src/wallets/schemas/wallet.schema.ts
+++ b/src/wallets/schemas/wallet.schema.ts
@@ -48,6 +48,10 @@ function isValidMongooseObjectId(id: string): boolean {
   return isValidObjectId(id);
 }
 
+function isValidWalletTrendType(type: string): boolean {
+  return ['daily', 'weekly', 'monthly'].includes(type);
+}
+
 export const addWalletSchema = object({
   body: object({
     walletAddresses: array(string(), {
@@ -86,6 +90,17 @@ export const updateWalletSchema = object({
       .optional(),
     name_tag: string()
       .refine(isNameTagUnique, { message: 'Name tag must be unique' })
+      .optional()
+  })
+});
+
+export const walletTrendQuerySchema = object({
+  query: object({
+    type: string()
+      .toLowerCase()
+      .refine(isValidWalletTrendType, {
+        message: "Type must be either 'daily', 'weekly' or 'montly'"
+      })
       .optional()
   })
 });

--- a/src/wallets/types/wallet.trend.types.ts
+++ b/src/wallets/types/wallet.trend.types.ts
@@ -1,0 +1,1 @@
+export type WalletTrendType = 'daily' | 'weekly' | 'monthly';

--- a/src/wallets/wallet.controller.ts
+++ b/src/wallets/wallet.controller.ts
@@ -4,6 +4,7 @@ import { Request, Response } from 'express';
 import { AddWalletsDto } from './dtos/add-wallets.dto';
 import { UserDocument } from '../models/user';
 import { UpdateWalletDto } from './dtos/update-wallet.dto';
+import { GetWalletTrendDto } from './dtos/get-wallet-trend.dto';
 
 @Service()
 export class WalletController {
@@ -13,6 +14,7 @@ export class WalletController {
     this.getOneById = this.getOneById.bind(this);
     this.updateOneById = this.updateOneById.bind(this);
     this.delete = this.delete.bind(this);
+    this.getWalletBalanceTrend = this.getWalletBalanceTrend.bind(this);
   }
 
   async add(req: Request, res: Response) {
@@ -66,6 +68,21 @@ export class WalletController {
     return res.status(200).json({
       status: 'success',
       data: wallet
+    });
+  }
+
+  async getWalletBalanceTrend(req: Request, res: Response) {
+    const user = req.user as UserDocument;
+    const { id } = req.params;
+    const { type } = req.query as GetWalletTrendDto;
+    const trendData = await this.service.getWalletBalanceTrend(
+      id,
+      user._id,
+      type
+    );
+    return res.status(200).json({
+      status: 'success',
+      data: trendData
     });
   }
 }

--- a/src/wallets/wallet.service.ts
+++ b/src/wallets/wallet.service.ts
@@ -6,6 +6,7 @@ import { UserDocument } from '../models/user';
 import CustomError from '../errors/custom-error';
 import { FilterQuery } from 'mongoose';
 import { UpdateWalletDto } from './dtos/update-wallet.dto';
+import { WalletTrendType } from './types/wallet.trend.types';
 
 @Service()
 export class WalletService {
@@ -120,5 +121,38 @@ export class WalletService {
       throw new CustomError(403, 'Unauthorized');
     }
     return wallet.deleteOne();
+  }
+
+  async getWalletBalanceTrend(
+    id: string,
+    userId: string,
+    type: WalletTrendType = 'daily'
+  ) {
+    const wallet = await this.model
+      .findOne({
+        _id: id
+      })
+      .exec();
+    if (!wallet) {
+      throw new CustomError(404, 'Wallet not found');
+    }
+    if (userId != String(wallet.user_id)) {
+      throw new CustomError(403, 'Unauthorized');
+    }
+    switch (type) {
+      case 'monthly':
+        return this.walletBalanceHistoryModel.getMonthlyAddressBalanceChange(
+          wallet.address
+        );
+      case 'weekly':
+        return this.walletBalanceHistoryModel.getWeeklyAddressBalanceChange(
+          wallet.address
+        );
+      case 'daily':
+      default:
+        return this.walletBalanceHistoryModel.getDailyAddressBalanceChange(
+          wallet.address
+        );
+    }
   }
 }


### PR DESCRIPTION
## Overview
This pull request introduces new routes to retrieve daily, weekly, and monthly balance trends. The changes include the implementation of endpoints to fetch wallet balance trends data for different time frames.

### Commits
- **feat: 🎸 add routes to get daily, weekly, monthly balance trends**
  - Implemented routes to retrieve wallet balance trends data.

### Timeline
- Commits were made with a focus on enhancing the API with the ability to retrieve balance trends over specific time frames.
